### PR TITLE
Change Toybox service to ADDB's Github

### DIFF
--- a/ManifestUpdater/Resources/internal_manifest.json
+++ b/ManifestUpdater/Resources/internal_manifest.json
@@ -1318,8 +1318,9 @@
       "Type": "UMM"
     },
     "Service": {
-      "Nexus": {
-        "ModID": "8"
+      "GitHub": {
+        "Owner": "xADDBx",
+        "RepoName": "ToyBox-Wrath"
       }
     },
     "About": "Toy Box is a cute and playful mod with 400+ cheats, tweaks and quality of life improvements. It was created in the spirit of Bag of Tricks & Cheat Menu but with a little different focus.",


### PR DESCRIPTION
Since ADDB is basically the sole maintainer of Toybox atm, and he has recently started doing Toybox releases on his Github, we would like to point the service to the Github (Possibly until Narria returns? Who knows?)